### PR TITLE
Updated Transformer Model Attention Mask

### DIFF
--- a/fairmotion/models/transformer.py
+++ b/fairmotion/models/transformer.py
@@ -162,6 +162,12 @@ class TransformerModel(nn.Module):
                 max_len, src.shape[1], src.shape[-1],
             ).type_as(src.data)
             next_pose = tgt[0].clone()
+
+            # Create mask for greedy encoding across the decoded output
+            tgt_mask = self._generate_square_subsequent_mask(max_len).to(
+                device=tgt.device
+            )
+            
             for i in range(max_len):
                 decoder_input[i] = next_pose
                 pos_encoded_input = self.pos_encoder(


### PR DESCRIPTION
The baseline main attention mask did not match the size of the decoder input and would therefor result in a dimension mismatch when running self.transformer_decoder because the tgt when running in inference mode is only the last sequence in the source sequence (dimension in the sequence length is 1), which does not necessarily match the max_len dimension (24 for the baseline data).

This bug was determined by running preprocessed data from the DIP dataset for which the motion_prediction task was made compatible with: https://dip.is.tuebingen.mpg.de/download.php. Training over 10 epochs with a batchsize of 24 was used to qualify that the change worked using the CMU dataset (16430 training sequences, 670 validation sequences, and 805 test sequences). The results are shown in below:
![loss](https://user-images.githubusercontent.com/68315344/142141753-be1a9c4a-b68d-4a1b-8b79-f528ead0065a.png)
